### PR TITLE
Do not overwrite the status line

### DIFF
--- a/autoload/github_dashboard.vim
+++ b/autoload/github_dashboard.vim
@@ -1008,7 +1008,7 @@ function! s:init_tab(...)
   endif
   let b:github_more_url = b:github_init_url
 
-  setlocal statusline=%!github_dashboard#statusline()
+  " setlocal statusline=%!github_dashboard#statusline()
 
   syntax clear
   syntax region githubTitle start=/^ \{0,2}[0-9]/ end="\n" oneline contains=githubNumber,Keyword,githubRepo,githubUser,githubTime,githubRef,githubCommit,githubTag,githubBranch,githubGist


### PR DESCRIPTION
I think that overwrite the status line with the plugin's one by default is a bad practice.

I think that is better to offer the `%{github_dashboard#statusline()}` option to customize the status line, IMHO is a better solution. Otherwise plugins like vim-powerline, powerline, vim-airline, ... are broke when you overwrite the status line. Is better customize them to integrate your plugin, as I did for example in vim-airline as follows:

``` VimL
function! GHDashboard (...)
  if &filetype == 'github-dashboard'
    " first variable is the statusline builder
    let builder = a:1

    call builder.add_section('airline_a', 'GitHub ')
    call builder.add_section('airline_b',
                \ ' %{get(split(get(split(github_dashboard#statusline(), " "),
                \ 1, ""), ":"), 0, "")} ')
    call builder.add_section('airline_c',
                \ ' %{get(split(get(split(github_dashboard#statusline(), " "),
                \ 2, ""), "]"), 0, "")} ')

    " tell the core to use the contents of the builder
    return 1
  endif
endfunction

autocmd FileType github-dashboard call airline#add_statusline_func('GHDashboard')
```

And that's the result:

![gh_dashboard](https://f.cloud.github.com/assets/390964/1102950/10eb616e-1873-11e3-85cb-05875035a4fc.png)
