### PR TITLE
Open items with o, too

### DIFF
--- a/autoload/github_dashboard.vim
+++ b/autoload/github_dashboard.vim
@@ -1194,6 +1194,7 @@ function! github_dashboard#open(auth, type, ...)
   nnoremap <silent> <buffer> q             :bd<cr>
   nnoremap <silent> <buffer> R             :call <SID>refresh()<cr>
   nnoremap <silent> <buffer> <cr>          :call <SID>action()<cr>
+  nnoremap <silent> <buffer> o             :call <SID>action()<cr>
   nnoremap <silent> <buffer> <2-LeftMouse> :call <SID>action()<cr>
   nnoremap <silent> <buffer> <c-n>         :silent! call <SID>next_item('')<cr>
   nnoremap <silent> <buffer> <c-p>         :silent! call <SID>next_item('b')<cr>


### PR DESCRIPTION
Many vim tools support `o` as well as `<CR>` when opening things. Finding myself reaching for `o` quite a bit when using GHD, I thought I'd send over a patch.