### PR TITLE
Windows: prefer :! instead of system()

### DIFF
--- a/autoload/github_dashboard.vim
+++ b/autoload/github_dashboard.vim
@@ -1236,7 +1236,9 @@ function! s:open_url(url)
     if s:is_mac
       let cmd = 'open'
     elseif s:is_win
-      let cmd = 'start rundll32 url.dll,FileProtocolHandler'
+      execute ':silent !start rundll32 url.dll,FileProtocolHandler'
+            \ shellescape(fnameescape(a:url))
+      return
     elseif executable('xdg-open')
       let cmd = 'xdg-open'
     else


### PR DESCRIPTION
system() pipes its command through a temp file, which has a history of problems on gvim for Windows. For whatever reason, after upgrading to gvim 7.4.618 (using the [kaoriya build](http://files.kaoriya.net/vim/)), links in github-dashboard silently fail. I debugged and verified that the command sent to system() is:

    start rundll32 url.dll,FileProtocolHandler "https://github.com/neovim/neovim/pull/1996"

This works when I run it directly in cmd.exe, but fails miserably via in gvim:

    call system('start rundll32 url.dll,FileProtocolHandler "https://github.com/neovim/neovim/pull/1996"')
    E484: Can't open file C:\Users\foo\...\blah.tmp


Side-note: `!start http://...` works just fine on Windows 7 (instead of `start rundll32 ...`). I don't know if rundll32 is something needed for older versions of Windows, so I didn't change it.

P.S.: Neovim on Windows won't have this problem.