### PR TITLE
neovim: Avoid CTRL-C watcher thread.

### DIFF
--- a/autoload/github_dashboard.vim
+++ b/autoload/github_dashboard.vim
@@ -1366,13 +1366,15 @@ module GitHubDashboard
     end
 
     def more
-      main = Thread.current
-      watcher = Thread.new {
-        while VIM::evaluate('getchar(1)')
-          sleep 0.1
-        end
-        main.kill
-      }
+      if 0 == VIM::evaluate('has("nvim")')
+        main = Thread.current
+        watcher = Thread.new {
+          while VIM::evaluate('getchar(1)')
+            sleep 0.1
+          end
+          main.kill
+        }
+      end
       overbose = $VERBOSE
       $VERBOSE = nil
       username = VIM::evaluate('b:github_username')


### PR DESCRIPTION
- CTRL-C works with neovim's if_ruby provider without the need for
  a watcher thread.
- neovim's if_ruby provider does not support multithreading yet
  https://github.com/neovim/neovim/pull/4980