### PR TITLE
Support empty commit messages in activity

### DIFF
--- a/autoload/github_dashboard.vim
+++ b/autoload/github_dashboard.vim
@@ -1509,7 +1509,7 @@ module GitHubDashboard
         ref_url = repo_url + "/tree/#{branch}"
         [["[#{who}] pushed to [#{branch}] at [#{repo}]", who_url, ref_url, repo_url]] +
         data['commits'].map { |commit|
-          title = emoji commit['message'].lines.first.chomp
+          title = emoji (commit['message'].lines.first || "").chomp
           ["[#{commit['sha'][0, 7]}] #{title}", repo_url + '/commit/' + commit['sha']]
         }
       when 'ReleaseEvent'


### PR DESCRIPTION
This is somewhat of an edge case. Currently `GHActivity` breaks if a commit was pushed w/o a message.

Return a title of "" if the commit message is empty. This is similar to
how `git log --oneline` prints commits lacking a message.